### PR TITLE
Use OpenAL Soft module from runtime

### DIFF
--- a/org.rolisteam.rolisteam.json
+++ b/org.rolisteam.rolisteam.json
@@ -31,25 +31,6 @@
           "tag": "v20.12.0",
           "commit": "50d31048dabcc20a47dee28239bee37a15f48b71"
         }
-      ],
-      "modules": [
-        {
-          "name": "openal",
-          "buildsystem": "cmake-ninja",
-          "config-opts": [
-              "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
-              "-DALSOFT_EXAMPLES=OFF",
-              "-DALSOFT_TESTS=OFF"
-          ],
-          "sources": [
-            {
-              "type": "git",
-              "url": "https://github.com/kcat/openal-soft.git",
-              "tag": "openal-soft-1.18.2",
-              "commit": "ce6076091bac3c00cd10803916e8911495580bd0"
-            }
-          ]
-        }
       ]
     },
     {


### PR DESCRIPTION
KDE runtime version 5.15-25.08 (based on the Freedesktop runtime version 25.08) appears to provide the appears to provide the **OpenAL Soft** module. 

In most cases, you don't need to build this module separately, unless your project requires a specific version or a custom configuration. 

**Related manifest file:** 

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/25.08/elements/components/openal.bst

**Related manifest file:** 

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/25.08/elements/components/mpfr.bst

**Other modules provided by the Freedesktop 25.08**

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/25.08/elements/platform.bst